### PR TITLE
Update stylesheet_instantSearch.css

### DIFF
--- a/INSTALL/includes/templates/YOUR_TEMPLATE/css/stylesheet_instantSearch.css
+++ b/INSTALL/includes/templates/YOUR_TEMPLATE/css/stylesheet_instantSearch.css
@@ -3,6 +3,7 @@ edit the position of the search box by uncommenting and changing the left and to
 Also make sure you set autoPosition = false in jscript_instantSearch.js*/
 
 .resultsContainer {
+  box-sizing:border-box;
   display: none;
   position: absolute;
   /*left: 100px;*/
@@ -19,9 +20,9 @@ Also make sure you set autoPosition = false in jscript_instantSearch.js*/
   background-color: #fff;
   margin: 0;
   padding: 5px;
-  -moz-box-shadow: 0px 2px 8px #000000;
-  -webkit-box-shadow: 0px 2px 8px #000000;
-  box-shadow: 0px 2px 8px #000000;
+  -moz-box-shadow: 0 2px 8px #000000;
+  -webkit-box-shadow: 0 2px 8px #000000;
+  box-shadow: 0 2px 8px #000000;
 }
 
 .resultsContainer .resultWrapper {


### PR DESCRIPTION
Any time a 0 in padding or margins, putting any unit with the 0 is confusing to the browser and slows the process.  You may not get an error or warning but, the syntax is incorrect.

Lines 18 and 21 might "bust the box" unless you add the box-sizing:border-box;    https://css-tricks.com/almanac/properties/b/box-sizing/  Note that this will not work with old versions of IE.  Specifically, versions 6 and 7 which were EOL in 2010 before Windows XP

Lines 27-30 are not validating for some reason.  It may be just the fact that flex has a problem with older versions of IE.  I will know better when I load this mod for trial.  https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-properties