### PR TITLE
modify parameter list so that sqlProduct is writeable

### DIFF
--- a/INSTALL/includes/classes/ajax/zcAjaxInstantSearch.php
+++ b/INSTALL/includes/classes/ajax/zcAjaxInstantSearch.php
@@ -42,7 +42,7 @@ class zcAjaxInstantSearch extends base
                            AND ((pd.products_name REGEXP :wordSearchPlus:) OR (p.products_model REGEXP :wordSearchPlus:) OR (LEFT(pd.products_name, LENGTH(:wordSearch:)) SOUNDS LIKE :wordSearch:))
                            AND language_id = '" . (int)$_SESSION['languages_id'] . "'";
 
-            $this->notify('NOTIFY_INSTANT_SEARCH_QUERY', $sqlProduct);
+            $this->notify('NOTIFY_INSTANT_SEARCH_QUERY', '', $sqlProduct);
 
             $sqlProduct = $db->bindVars($sqlProduct, ':wordSearch:', $wordSearch, 'string');
             $sqlProduct = $db->bindVars($sqlProduct, ':wordSearchPlus:', $wordSearchPlus, 'string');


### PR DESCRIPTION
as indicated here:

https://docs.zen-cart.com/dev/code/notifiers/

`$param1` is read only.  so `$sqlProduct` would need to be set at `$parm2` in order to be writeable.